### PR TITLE
fix: upload and read files in bytes

### DIFF
--- a/ipfs_client/tests/init_read_bytes_test.py
+++ b/ipfs_client/tests/init_read_bytes_test.py
@@ -1,3 +1,4 @@
+import io
 import os
 
 from ipfs_client.main import AsyncIPFSClientSingleton
@@ -10,9 +11,9 @@ from ipfs_client.settings.data_models import IPFSWriterRateLimit
 # run this test as:
 # IPFS_URL=https://ipfs.infura.io:5001 IPFS_AUTH_API_KEY=your_api_key
 # IPFS_AUTH_API_SECRET=your_api_secret poetry run python -m
-# ipfs_client.tests.init_read_test
+# ipfs_client.tests.init_read_bytes_test /path/to/binary/file
 
-async def test_read_from_cid():
+async def test_upload_read_binary(binary_file_path):
     ipfs_url = os.getenv('IPFS_URL', 'http://localhost:5001')
     ipfs_auth_api_key = os.getenv('IPFS_AUTH_API_KEY', None)
     ipfs_auth_api_secret = os.getenv('IPFS_AUTH_API_SECRET', None)
@@ -43,12 +44,15 @@ async def test_read_from_cid():
         settings=ipfs_client_settings,
     )
     await ipfs_client.init_sessions()
-    cid = await ipfs_client._ipfs_write_client.add_json({'test': 'test'})
+    file_contents = io.open(binary_file_path, 'rb').read()
+    cid = await ipfs_client._ipfs_write_client.add_bytes(file_contents)
     print(cid)
-    data = await ipfs_client._ipfs_read_client.get_json(cid)
+    data = await ipfs_client._ipfs_read_client.cat(cid, bytes_mode=True)
     print(data)
 
 
 if __name__ == '__main__':
     import asyncio
-    asyncio.run(test_read_from_cid())
+    import sys
+    binary_file_upload_path = sys.argv[1]
+    asyncio.run(test_upload_read_binary(binary_file_upload_path))


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #5 

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.


### Current behaviour
As explained in #5 

### New expected behaviour
Check test case in 

https://github.com/PowerLoom/py-ipfs-client/blob/57210990f9a74e61020b7aeab307b2deb80819ed/ipfs_client/tests/init_read_bytes_test.py#L47-L51

### Change logs

#### Added 

*`cat()` now supports a `bytes_mode` flag

https://github.com/PowerLoom/py-ipfs-client/blob/57210990f9a74e61020b7aeab307b2deb80819ed/ipfs_client/main.py#L101-L102


#### Fixed

* `add_bytes()` now returns the CID instead of the entire response dict from IPFS node

<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
Upgrade to the latest version from your package and/or build manager
