### PR TITLE
Feat/remote pinning

### DIFF
--- a/ipfs_client/settings/data_models.py
+++ b/ipfs_client/settings/data_models.py
@@ -25,7 +25,7 @@ class RemotePinningConfig(BaseModel):
     service_name: Optional[str] = ""
     service_endpoint: Optional[str] = ""
     service_token: Optional[str] = ""
-    background_pinning: bool = False
+    background_pinning: Optional[bool] = False
 
 
 class IPFSConfig(BaseModel):

--- a/ipfs_client/settings/data_models.py
+++ b/ipfs_client/settings/data_models.py
@@ -20,6 +20,14 @@ class ExternalAPIAuth(BaseModel):
     apiSecret: str = ''
 
 
+class RemotePinningConfig(BaseModel):
+    enabled: bool
+    service_name: Optional[str] = ""
+    service_endpoint: Optional[str] = ""
+    service_token: Optional[str] = ""
+    background_pinning: bool = False
+
+
 class IPFSConfig(BaseModel):
     url: str
     url_auth: Optional[ExternalAPIAuth] = None
@@ -29,3 +37,4 @@ class IPFSConfig(BaseModel):
     timeout: int
     local_cache_path: str
     connection_limits: ConnectionLimits
+    remote_pinning: RemotePinningConfig

--- a/ipfs_client/tests/init_read_bytes_test.py
+++ b/ipfs_client/tests/init_read_bytes_test.py
@@ -6,6 +6,7 @@ from ipfs_client.settings.data_models import ConnectionLimits
 from ipfs_client.settings.data_models import ExternalAPIAuth
 from ipfs_client.settings.data_models import IPFSConfig
 from ipfs_client.settings.data_models import IPFSWriterRateLimit
+from ipfs_client.settings.data_models import RemotePinningConfig
 
 
 # run this test as:
@@ -14,7 +15,7 @@ from ipfs_client.settings.data_models import IPFSWriterRateLimit
 # ipfs_client.tests.init_read_bytes_test /path/to/binary/file
 
 async def test_upload_read_binary(binary_file_path):
-    ipfs_url = os.getenv('IPFS_URL', 'http://localhost:5001')
+    ipfs_url = os.getenv('IPFS_URL', 'http://localhost:5002')
     ipfs_auth_api_key = os.getenv('IPFS_AUTH_API_KEY', None)
     ipfs_auth_api_secret = os.getenv('IPFS_AUTH_API_SECRET', None)
     ipfs_client_settings = IPFSConfig(
@@ -29,6 +30,12 @@ async def test_upload_read_binary(binary_file_path):
             max_connections=10,
             max_keepalive_connections=5,
             keepalive_expiry=60,
+        ),
+        remote_pinning=RemotePinningConfig(
+            enabled=False,
+            service_name='',
+            service_endpoint='',
+            service_token='',
         ),
     )
     if all([ipfs_auth_api_key, ipfs_auth_api_secret]):
@@ -47,7 +54,7 @@ async def test_upload_read_binary(binary_file_path):
     file_contents = io.open(binary_file_path, 'rb').read()
     cid = await ipfs_client._ipfs_write_client.add_bytes(file_contents)
     print(cid)
-    data = await ipfs_client._ipfs_read_client.cat(cid, bytes_mode=True)
+    data = await ipfs_client._ipfs_read_client.cat(cid, bytes_mode=False)
     print(data)
 
 

--- a/ipfs_client/tests/init_read_bytes_test.py
+++ b/ipfs_client/tests/init_read_bytes_test.py
@@ -14,8 +14,9 @@ from ipfs_client.settings.data_models import RemotePinningConfig
 # IPFS_AUTH_API_SECRET=your_api_secret poetry run python -m
 # ipfs_client.tests.init_read_bytes_test /path/to/binary/file
 
+
 async def test_upload_read_binary(binary_file_path):
-    ipfs_url = os.getenv('IPFS_URL', 'http://localhost:5002')
+    ipfs_url = os.getenv('IPFS_URL', 'http://localhost:5001')
     ipfs_auth_api_key = os.getenv('IPFS_AUTH_API_KEY', None)
     ipfs_auth_api_secret = os.getenv('IPFS_AUTH_API_SECRET', None)
     ipfs_client_settings = IPFSConfig(

--- a/ipfs_client/tests/init_read_test.py
+++ b/ipfs_client/tests/init_read_test.py
@@ -5,7 +5,7 @@ from ipfs_client.settings.data_models import ConnectionLimits
 from ipfs_client.settings.data_models import ExternalAPIAuth
 from ipfs_client.settings.data_models import IPFSConfig
 from ipfs_client.settings.data_models import IPFSWriterRateLimit
-
+from ipfs_client.settings.data_models import RemotePinningConfig
 
 # run this test as:
 # IPFS_URL=https://ipfs.infura.io:5001 IPFS_AUTH_API_KEY=your_api_key
@@ -13,7 +13,7 @@ from ipfs_client.settings.data_models import IPFSWriterRateLimit
 # ipfs_client.tests.init_read_test
 
 async def test_read_from_cid():
-    ipfs_url = os.getenv('IPFS_URL', 'http://localhost:5001')
+    ipfs_url = os.getenv('IPFS_URL', 'http://localhost:5002')
     ipfs_auth_api_key = os.getenv('IPFS_AUTH_API_KEY', None)
     ipfs_auth_api_secret = os.getenv('IPFS_AUTH_API_SECRET', None)
     ipfs_client_settings = IPFSConfig(
@@ -28,6 +28,12 @@ async def test_read_from_cid():
             max_connections=10,
             max_keepalive_connections=5,
             keepalive_expiry=60,
+        ),
+        remote_pinning=RemotePinningConfig(
+            enabled=False,
+            service_name='',
+            service_endpoint='',
+            service_token='',
         ),
     )
     if all([ipfs_auth_api_key, ipfs_auth_api_secret]):

--- a/ipfs_client/tests/init_remote_pinning_test.py
+++ b/ipfs_client/tests/init_remote_pinning_test.py
@@ -17,6 +17,9 @@ async def test_read_from_cid():
     ipfs_url = os.getenv('IPFS_URL', 'http://localhost:5001')
     ipfs_auth_api_key = os.getenv('IPFS_AUTH_API_KEY', None)
     ipfs_auth_api_secret = os.getenv('IPFS_AUTH_API_SECRET', None)
+    remote_pinning_service_name = os.getenv('REMOTE_PINNING_SERVICE_NAME', None)
+    remote_pinning_service_endpoint = os.getenv('REMOTE_PINNING_SERVICE_ENDPOINT', None)
+    remote_pinning_service_token = os.getenv('REMOTE_PINNING_SERVICE_TOKEN', None)
     ipfs_client_settings = IPFSConfig(
         url=ipfs_url,
         reader_url=ipfs_url,
@@ -31,10 +34,11 @@ async def test_read_from_cid():
             keepalive_expiry=60,
         ),
         remote_pinning=RemotePinningConfig(
-            enabled=False,
-            service_name='',
-            service_endpoint='',
-            service_token='',
+            enabled=True,
+            service_name=remote_pinning_service_name,
+            service_endpoint=remote_pinning_service_endpoint,
+            service_token=remote_pinning_service_token,
+            background_pinning=False,
         ),
     )
     if all([ipfs_auth_api_key, ipfs_auth_api_secret]):


### PR DESCRIPTION
FEAT: [Remote Pinning Support](https://docs.ipfs.tech/how-to/work-with-pinning-services/)

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
Remote pinning is not supported

### New expected behaviour
Remote pinning is supported

### Change logs
- Automatically adds a remote pinning service is not already added using https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-pin-remote-service-add
- Automatically pins to the configured remote pinning service (if configured) using https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-pin-remote-add
- Config data model now needs `RemotePinning` configuration
```python
class RemotePinningConfig(BaseModel):
    enabled: bool
    service_name: Optional[str] = ""
    service_endpoint: Optional[str] = ""
    service_token: Optional[str] = ""
    background_pinning: Optional[bool] = False
```